### PR TITLE
Added MauiAppBuilder extension method

### DIFF
--- a/src/Maui.Plugins.PageResolver/StartupExtensions.cs
+++ b/src/Maui.Plugins.PageResolver/StartupExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Hosting;
 
 namespace Maui.Plugins.PageResolver
 {
@@ -12,6 +13,18 @@ namespace Maui.Plugins.PageResolver
         {
             var sp = sc.BuildServiceProvider();
             Resolver.RegisterServiceProvider(sp);
+        }
+#
+        /// <summary>
+        /// Registers the services in the service collection with the page resolver
+        /// </summary>
+        /// <param name="builder"></param>
+        public static MauiAppBuilder UsePageResolver(this MauiAppBuilder builder)
+        {
+            var sp = builder.Services.BuildServiceProvider();
+            Resolver.RegisterServiceProvider(sp);
+
+            return builder;
         }
     }
 }

--- a/src/Maui.Plugins.PageResolver/StartupExtensions.cs
+++ b/src/Maui.Plugins.PageResolver/StartupExtensions.cs
@@ -14,7 +14,7 @@ namespace Maui.Plugins.PageResolver
             var sp = sc.BuildServiceProvider();
             Resolver.RegisterServiceProvider(sp);
         }
-#
+
         /// <summary>
         /// Registers the services in the service collection with the page resolver
         /// </summary>


### PR DESCRIPTION
Sorry if you already started this, just had some spare time to create a PR. #3 

Tested against my project that's already using your NuGet, and all seems ok.

```csharp
MauiAppBuilder? builder = MauiApp.CreateBuilder();
builder
    .UseMauiApp<App>()
    .UseMauiCommunityToolkit()
    .UsePageResolver()
    .ConfigureFonts(fonts =>
    {
        fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
        fonts.AddFont("la-solid-900.ttf", "LASolid");
    });

return builder.Build();
```