### PR TITLE
Use IMauiInitializeService interface to initialize the Resolver

### DIFF
--- a/src/DemoProject/DemoProject.csproj
+++ b/src/DemoProject/DemoProject.csproj
@@ -48,8 +48,8 @@
 
 	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
 		<!-- Required - WinUI does not yet have buildTransitive for everything -->
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
-		<PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.0.30" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0" />
+		<PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.3.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/DemoProject/MauiProgram.cs
+++ b/src/DemoProject/MauiProgram.cs
@@ -1,5 +1,6 @@
 ﻿using DemoProject.Services;
 using DemoProject.ViewModels;
+using Maui.Plugins.PageResolver;
 
 namespace DemoProject
 {
@@ -10,18 +11,21 @@ namespace DemoProject
             var builder = MauiApp.CreateBuilder();
             builder
                 .UseMauiApp<App>()
+                //.UsePageResolver()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 });
 
-            UseAutoreg(builder.Services);
+            //UseAutoreg(builder.Services);
 
-            //builder.Services.AddTransient<MainPage>();
-
-            //builder.Services.AddTransient<MainViewModel>();
-
-            //builder.Services.AddSingleton<INameService, NameService>();
+            builder.Services.UsePageResolver();
+            builder.Services.AddTransient<MainPage>();
+            builder.Services.AddTransient<ParamPage>();
+            builder.Services.AddTransient<BaseViewModel>();
+            builder.Services.AddTransient<ParamViewModel>();
+            builder.Services.AddTransient<MainViewModel>();
+            builder.Services.AddSingleton<INameService, NameService>();
 
             return builder.Build();
         }

--- a/src/DemoProject/MauiProgram.cs
+++ b/src/DemoProject/MauiProgram.cs
@@ -17,15 +17,15 @@ namespace DemoProject
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 });
 
-            //UseAutoreg(builder.Services);
+            UseAutoreg(builder.Services);
 
-            builder.Services.UsePageResolver();
-            builder.Services.AddTransient<MainPage>();
-            builder.Services.AddTransient<ParamPage>();
-            builder.Services.AddTransient<BaseViewModel>();
-            builder.Services.AddTransient<ParamViewModel>();
-            builder.Services.AddTransient<MainViewModel>();
-            builder.Services.AddSingleton<INameService, NameService>();
+            //builder.Services.UsePageResolver();
+            //builder.Services.AddTransient<MainPage>();
+            //builder.Services.AddTransient<ParamPage>();
+            //builder.Services.AddTransient<BaseViewModel>();
+            //builder.Services.AddTransient<ParamViewModel>();
+            //builder.Services.AddTransient<MainViewModel>();
+            //builder.Services.AddSingleton<INameService, NameService>();
 
             return builder.Build();
         }

--- a/src/Maui.Plugins.PageResolver.Autoreg/Maui.Plugins.PageResolver.Autoreg.csproj
+++ b/src/Maui.Plugins.PageResolver.Autoreg/Maui.Plugins.PageResolver.Autoreg.csproj
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0-1.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Maui.Plugins.PageResolver/Initializer.cs
+++ b/src/Maui.Plugins.PageResolver/Initializer.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.Maui.Hosting;
+
+namespace Maui.Plugins.PageResolver
+{
+    internal class Initializer : IMauiInitializeService
+    {
+#region Implementation of IMauiInitializeService
+
+        /// <inheritdoc />
+        public void Initialize( IServiceProvider services )
+        {
+            Resolver.RegisterServiceProvider( services );
+        }
+
+#endregion
+    }
+}

--- a/src/Maui.Plugins.PageResolver/Resolver.cs
+++ b/src/Maui.Plugins.PageResolver/Resolver.cs
@@ -1,27 +1,10 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
-using Microsoft.Maui.Hosting;
 
 namespace Maui.Plugins.PageResolver
 {
     public static class Resolver
     {
-        internal class Initializer : IMauiInitializeService
-        {
-#region Implementation of IMauiInitializeService
-
-            /// <inheritdoc />
-            public void Initialize( IServiceProvider services )
-            {
-                if ( Resolver.scope == null )
-                {
-                    Resolver.RegisterServiceProvider( services );
-                }
-            }
-
-#endregion
-        }
-
         private static IServiceScope scope;
 
         /// <summary>
@@ -30,7 +13,7 @@ namespace Maui.Plugins.PageResolver
         /// <param name="sp"></param>
         internal static void RegisterServiceProvider(IServiceProvider sp)
         {
-            scope = sp.CreateScope();
+            scope ??= sp.CreateScope();
         }
 
         /// <summary>

--- a/src/Maui.Plugins.PageResolver/Resolver.cs
+++ b/src/Maui.Plugins.PageResolver/Resolver.cs
@@ -1,10 +1,27 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
+using Microsoft.Maui.Hosting;
 
 namespace Maui.Plugins.PageResolver
 {
     public static class Resolver
     {
+        internal class Initializer : IMauiInitializeService
+        {
+#region Implementation of IMauiInitializeService
+
+            /// <inheritdoc />
+            public void Initialize( IServiceProvider services )
+            {
+                if ( Resolver.scope == null )
+                {
+                    Resolver.RegisterServiceProvider( services );
+                }
+            }
+
+#endregion
+        }
+
         private static IServiceScope scope;
 
         /// <summary>

--- a/src/Maui.Plugins.PageResolver/StartupExtensions.cs
+++ b/src/Maui.Plugins.PageResolver/StartupExtensions.cs
@@ -11,7 +11,7 @@ public static class StartupExtensions
     /// <param name="sc"></param>
     public static void UsePageResolver(this IServiceCollection sc)
     {
-        sc.AddSingleton<IMauiInitializeService, Resolver.Initializer>();
+        sc.AddSingleton<IMauiInitializeService, Initializer>();
     }
 
     /// <summary>
@@ -20,7 +20,7 @@ public static class StartupExtensions
     /// <param name="builder"></param>
     public static MauiAppBuilder UsePageResolver(this MauiAppBuilder builder)
     {
-        builder.Services.AddSingleton<IMauiInitializeService, Resolver.Initializer>();
+        builder.Services.AddSingleton<IMauiInitializeService, Initializer>();
 
         return builder;
     }

--- a/src/Maui.Plugins.PageResolver/StartupExtensions.cs
+++ b/src/Maui.Plugins.PageResolver/StartupExtensions.cs
@@ -11,8 +11,7 @@ public static class StartupExtensions
     /// <param name="sc"></param>
     public static void UsePageResolver(this IServiceCollection sc)
     {
-        var sp = sc.BuildServiceProvider();
-        Resolver.RegisterServiceProvider(sp);
+        sc.AddSingleton<IMauiInitializeService, Resolver.Initializer>();
     }
 
     /// <summary>
@@ -21,9 +20,8 @@ public static class StartupExtensions
     /// <param name="builder"></param>
     public static MauiAppBuilder UsePageResolver(this MauiAppBuilder builder)
     {
-        var sp = builder.Services.BuildServiceProvider();
-        Resolver.RegisterServiceProvider(sp);
+        builder.Services.AddSingleton<IMauiInitializeService, Resolver.Initializer>();
 
         return builder;
-    }        
+    }
 }


### PR DESCRIPTION
PR for https://github.com/matt-goldman/Maui.Plugins.PageResolver/issues/10

Maui resolves and calls `IMauiInitializeService.Initialize()` inside `MauiApp.Build()`. Thus this allows the UsePageResolver method to be called at any point during the Fluent init process or at any time before Builder.Build is called. Should also allow multiple libraries to call it and it will only resolve once.

[MS DI Docs](https://docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection#service-registration-methods) explain that you can register the same Interface/Concrete class singleton multiple times in MS DI. So the `Resolver.Initializer.Initialize` method will be called for each time the startup method is called. The is null test will filter it out.  