### PR TITLE
Only register the IMauiInitializeService a single time.

### DIFF
--- a/src/Maui.Plugins.PageResolver/StartupExtensions.cs
+++ b/src/Maui.Plugins.PageResolver/StartupExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Maui.Hosting;
 
 namespace Maui.Plugins.PageResolver;
@@ -11,7 +12,7 @@ public static class StartupExtensions
     /// <param name="sc"></param>
     public static void UsePageResolver(this IServiceCollection sc)
     {
-        sc.AddSingleton<IMauiInitializeService, Initializer>();
+        sc.TryAddEnumerable( ServiceDescriptor.Transient<IMauiInitializeService, Initializer>() );
     }
 
     /// <summary>
@@ -20,7 +21,8 @@ public static class StartupExtensions
     /// <param name="builder"></param>
     public static MauiAppBuilder UsePageResolver(this MauiAppBuilder builder)
     {
-        builder.Services.AddSingleton<IMauiInitializeService, Initializer>();
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Transient<IMauiInitializeService, Initializer>() );
 
         return builder;
     }


### PR DESCRIPTION
PR for issue #12 

TryAddEnumerable extension method will result in only a single registration, which will reduce the memory footprint and registered services at runtime if initialized from multiple sources.

As it appears you've not released the NuGet that has the previous initialization change I thought I'd add a further update that helps reduce the memory footprint of the previous implementation so it can make the next release and you only have to turn the crank once.