### PR TITLE
Fix: ViewModel crash

### DIFF
--- a/src/Maui.Plugins.PageResolver/NavigationExtensions.cs
+++ b/src/Maui.Plugins.PageResolver/NavigationExtensions.cs
@@ -144,7 +144,7 @@ public static class NavigationExtensions
         var pageType = typeof(T);
         var viewModelType = Resolver.GetViewModelType(pageType);
 
-        if (parameters.Any(x => x.GetType().Equals(viewModelType)))
+        if (viewModelType is not null && parameters.Any(x => x.GetType().Equals(viewModelType)))
         {
             viewModelType = null;
         }

--- a/src/Maui.Plugins.PageResolver/NavigationExtensions.cs
+++ b/src/Maui.Plugins.PageResolver/NavigationExtensions.cs
@@ -144,12 +144,12 @@ public static class NavigationExtensions
         var pageType = typeof(T);
         var viewModelType = Resolver.GetViewModelType(pageType);
 
-        if(parameters.Any(x => x.GetType().Equals(viewModelType)))
+        if (parameters.Any(x => x.GetType().Equals(viewModelType)))
         {
             viewModelType = null;
         }
 
-        if(viewModelType == null)
+        if (viewModelType == null)
         {
             return CreatePageWithoutViewModel<T>(serviceProvider, parameters);
         }
@@ -165,13 +165,13 @@ public static class NavigationExtensions
     private static Page CreatePageWithViewModel<T>(IServiceProvider serviceProvider, Type viewModelType, params object[] parameters) where T : Page
     {
         // Check if parameters fit the ViewModel's constructors
-        if(ParametersMatchConstructors(viewModelType, parameters))
+        if (ParametersMatchConstructors(viewModelType, parameters))
         {
             var viewModel = ActivatorUtilities.CreateInstance(serviceProvider, viewModelType, parameters);
             return CreatePageUsingViewModel<T>(serviceProvider, viewModel);
         }
         // Check if parameters fit the Page's constructors, excluding the ViewModel type
-        else if(ParametersMatchConstructorsExcludingType(typeof(T), viewModelType, parameters))
+        else if (ParametersMatchConstructorsExcludingType(typeof(T), viewModelType, parameters))
         {
             return ActivatorUtilities.CreateInstance<T>(serviceProvider, parameters);
         }
@@ -186,19 +186,19 @@ public static class NavigationExtensions
         var sp = Resolver.GetServiceProvider();
 
         var constructors = type.GetConstructors();
-        foreach(var constructor in constructors)
+        foreach (var constructor in constructors)
         {
             var ctorParams = constructor.GetParameters();
 
             var nonInjectableParams = ctorParams.Where(p => !IsRegisteredDependency(sp, p.ParameterType)).ToArray();
 
-            if(nonInjectableParams.Length == parameters.Length)
+            if (nonInjectableParams.Length == parameters.Length)
             {
-                for(int i = 0; i < nonInjectableParams.Length; i++)
+                for (int i = 0; i < nonInjectableParams.Length; i++)
                 {
-                    if(!nonInjectableParams[i].ParameterType.IsAssignableFrom(parameters[i].GetType()))
+                    if (!nonInjectableParams[i].ParameterType.IsAssignableFrom(parameters[i].GetType()))
                         break;
-                    if(i == nonInjectableParams.Length - 1)
+                    if (i == nonInjectableParams.Length - 1)
                         return true; // all parameters match
                 }
             }
@@ -211,19 +211,19 @@ public static class NavigationExtensions
         var sp = Resolver.GetServiceProvider();
 
         var constructors = type.GetConstructors();
-        foreach(var constructor in constructors)
+        foreach (var constructor in constructors)
         {
             var ctorParams = constructor.GetParameters().Where(p => p.ParameterType != excludeType).ToArray();
 
             var nonInjectableParams = ctorParams.Where(p => !IsRegisteredDependency(sp, p.ParameterType)).ToArray();
 
-            if(nonInjectableParams.Length == parameters.Length)
+            if (nonInjectableParams.Length == parameters.Length)
             {
-                for(int i = 0; i < nonInjectableParams.Length; i++)
+                for (int i = 0; i < nonInjectableParams.Length; i++)
                 {
-                    if(!nonInjectableParams[i].ParameterType.IsAssignableFrom(parameters[i].GetType()))
+                    if (!nonInjectableParams[i].ParameterType.IsAssignableFrom(parameters[i].GetType()))
                         break;
-                    if(i == nonInjectableParams.Length - 1)
+                    if (i == nonInjectableParams.Length - 1)
                         return true; // all parameters match
                 }
             }
@@ -237,7 +237,7 @@ public static class NavigationExtensions
         {
             return ActivatorUtilities.CreateInstance<T>(serviceProvider, viewModel);
         }
-        catch(MissingMemberException)
+        catch (MissingMemberException)
         {
             return ActivatorUtilities.CreateInstance<T>(Resolver.GetServiceProvider());
         }
@@ -245,7 +245,7 @@ public static class NavigationExtensions
 
     private static bool IsRegisteredDependency(IServiceProvider serviceProvider, Type type)
     {
-        if(type.IsPrimitive || type == typeof(string) || type.IsValueType)
+        if (type.IsPrimitive || type == typeof(string) || type.IsValueType)
         {
             return false;
         }
@@ -255,7 +255,7 @@ public static class NavigationExtensions
             var services = serviceProvider.GetServices(type);
             return services.Any();
         }
-        catch(Exception)
+        catch (Exception)
         {
             return false;
         }

--- a/src/Maui.Plugins.PageResolver/NavigationExtensions.cs
+++ b/src/Maui.Plugins.PageResolver/NavigationExtensions.cs
@@ -69,8 +69,7 @@ public static class NavigationExtensions
         return window;
     }
 
-    #endregion
-
+    #endregion paramaterless navigation
 
     #region parameterized navigation
 
@@ -136,7 +135,7 @@ public static class NavigationExtensions
         return window;
     }
 
-    #endregion
+    #endregion parameterized navigation
 
     internal static Page ResolvePage<T>(params object[] parameters) where T : Page
     {
@@ -145,7 +144,12 @@ public static class NavigationExtensions
         var pageType = typeof(T);
         var viewModelType = Resolver.GetViewModelType(pageType);
 
-        if (viewModelType == null)
+        if(parameters.Any(x => x.GetType().Equals(viewModelType)))
+        {
+            viewModelType = null;
+        }
+
+        if(viewModelType == null)
         {
             return CreatePageWithoutViewModel<T>(serviceProvider, parameters);
         }
@@ -161,13 +165,13 @@ public static class NavigationExtensions
     private static Page CreatePageWithViewModel<T>(IServiceProvider serviceProvider, Type viewModelType, params object[] parameters) where T : Page
     {
         // Check if parameters fit the ViewModel's constructors
-        if (ParametersMatchConstructors(viewModelType, parameters))
+        if(ParametersMatchConstructors(viewModelType, parameters))
         {
             var viewModel = ActivatorUtilities.CreateInstance(serviceProvider, viewModelType, parameters);
             return CreatePageUsingViewModel<T>(serviceProvider, viewModel);
         }
         // Check if parameters fit the Page's constructors, excluding the ViewModel type
-        else if (ParametersMatchConstructorsExcludingType(typeof(T), viewModelType, parameters))
+        else if(ParametersMatchConstructorsExcludingType(typeof(T), viewModelType, parameters))
         {
             return ActivatorUtilities.CreateInstance<T>(serviceProvider, parameters);
         }
@@ -182,19 +186,19 @@ public static class NavigationExtensions
         var sp = Resolver.GetServiceProvider();
 
         var constructors = type.GetConstructors();
-        foreach (var constructor in constructors)
+        foreach(var constructor in constructors)
         {
             var ctorParams = constructor.GetParameters();
 
             var nonInjectableParams = ctorParams.Where(p => !IsRegisteredDependency(sp, p.ParameterType)).ToArray();
 
-            if (nonInjectableParams.Length == parameters.Length)
+            if(nonInjectableParams.Length == parameters.Length)
             {
-                for (int i = 0; i < nonInjectableParams.Length; i++)
+                for(int i = 0; i < nonInjectableParams.Length; i++)
                 {
-                    if (!nonInjectableParams[i].ParameterType.IsAssignableFrom(parameters[i].GetType()))
+                    if(!nonInjectableParams[i].ParameterType.IsAssignableFrom(parameters[i].GetType()))
                         break;
-                    if (i == nonInjectableParams.Length - 1)
+                    if(i == nonInjectableParams.Length - 1)
                         return true; // all parameters match
                 }
             }
@@ -207,19 +211,19 @@ public static class NavigationExtensions
         var sp = Resolver.GetServiceProvider();
 
         var constructors = type.GetConstructors();
-        foreach (var constructor in constructors)
+        foreach(var constructor in constructors)
         {
             var ctorParams = constructor.GetParameters().Where(p => p.ParameterType != excludeType).ToArray();
 
             var nonInjectableParams = ctorParams.Where(p => !IsRegisteredDependency(sp, p.ParameterType)).ToArray();
 
-            if (nonInjectableParams.Length == parameters.Length)
+            if(nonInjectableParams.Length == parameters.Length)
             {
-                for (int i = 0; i < nonInjectableParams.Length; i++)
+                for(int i = 0; i < nonInjectableParams.Length; i++)
                 {
-                    if (!nonInjectableParams[i].ParameterType.IsAssignableFrom(parameters[i].GetType()))
+                    if(!nonInjectableParams[i].ParameterType.IsAssignableFrom(parameters[i].GetType()))
                         break;
-                    if (i == nonInjectableParams.Length - 1)
+                    if(i == nonInjectableParams.Length - 1)
                         return true; // all parameters match
                 }
             }
@@ -233,7 +237,7 @@ public static class NavigationExtensions
         {
             return ActivatorUtilities.CreateInstance<T>(serviceProvider, viewModel);
         }
-        catch (MissingMemberException)
+        catch(MissingMemberException)
         {
             return ActivatorUtilities.CreateInstance<T>(Resolver.GetServiceProvider());
         }
@@ -241,7 +245,7 @@ public static class NavigationExtensions
 
     private static bool IsRegisteredDependency(IServiceProvider serviceProvider, Type type)
     {
-        if (type.IsPrimitive || type == typeof(string) || type.IsValueType)
+        if(type.IsPrimitive || type == typeof(string) || type.IsValueType)
         {
             return false;
         }
@@ -251,7 +255,7 @@ public static class NavigationExtensions
             var services = serviceProvider.GetServices(type);
             return services.Any();
         }
-        catch (Exception)
+        catch(Exception)
         {
             return false;
         }


### PR DESCRIPTION
Super edge case, and probably because I'm not following "mvvm pattern" 100%.

> We have a lot of user flows/ routes in our app (i.e. multiple pages to complete a single action). And to simplify development a single ViewModel is used throughout the route.

I have a use case where I can get to a page in multiple ways -

- Fresh flow and a parameter being sent to the viewModel
- Already started the flow, with the viewModel being passed to a new page

i.e.
- Straight to `Page A`
- Or start with `Page B` and pass the viewModel to `Page A`

Both `Page A` and `Page B` have been registered using `UpsertViewModelMapping`. As both could be the start of a flow. But `Page A` doesn't always need the ViewModel created.

The current code in `ResolvePage` simply calls `Resolver.GetViewModelType(pageType);` and presumes it needs to generate a ViewModel. To fix my use case I added a check on the parameters to see if the ViewModel has been passed in, and if it has it doesn't need to be generated.

Cant see this causing an issue for anyone else.

> hoped I explained it well enough lol.


