### PR TITLE
Fix swallowing original error

### DIFF
--- a/src/Maui.Plugins.PageResolver/NavigationExtensions.cs
+++ b/src/Maui.Plugins.PageResolver/NavigationExtensions.cs
@@ -239,7 +239,16 @@ public static class NavigationExtensions
         }
         catch (MissingMemberException)
         {
-            return ActivatorUtilities.CreateInstance<T>(Resolver.GetServiceProvider());
+            try
+            {
+                return ActivatorUtilities.CreateInstance<T>(Resolver.GetServiceProvider());
+            }
+            catch (Exception)
+            {
+                // Intentionally left blank
+            }
+
+            throw;
         }
     }
 


### PR DESCRIPTION
Had an issue with release builds, where testers where reporting a specific page crashing, when I looked at the logs it was pointing to the fact that a service was missing from the DI container - 
![image](https://github.com/user-attachments/assets/6e87bdd6-e055-4398-bd7d-90cf9ebfd33d)
![image](https://github.com/user-attachments/assets/44c04eaa-8392-46cd-bb72-a1fb43f72d18)



But everything was working fine when debugging. When I turned on trimming for the debug build I was able to replicate the issue, but was still getting the same error pointing to a service missing.

I had to clone PageResolver to be able to see the causing issue, which pointed to an issue with XAML accessing a property of an array using an index.

This PR is to return the original error, rather than the fallback attempt, which then results in the correct error being logged - 
![image](https://github.com/user-attachments/assets/3a85c778-7f47-44b7-b1c7-d9f1516d2b90)
![image](https://github.com/user-attachments/assets/eded1fbd-1864-4797-8bf1-f9dcb1b955da)


